### PR TITLE
Added module for Split Payments extension 

### DIFF
--- a/pylnbits/__init__.py
+++ b/pylnbits/__init__.py
@@ -44,4 +44,8 @@ Modules exported by this package:
 
 - `lndhub.py`: for fetching admin and invoice lndhub urls
 
+- `split_payments.py`: For target wallets, calls Rest API methods for LNbits Split Payments Extension
+    - List target wallets
+    - Add target wallet
+    - Delete a target wallet
 """

--- a/pylnbits/split_payments.py
+++ b/pylnbits/split_payments.py
@@ -48,8 +48,7 @@ class SplitPayments:
 
         """
         try:
-            upath = self.splitpath
-            path = self._lnbits_url + upath
+            path = self._lnbits_url + self.splitpath
             res = await get_url(self._session, path=path, headers=self._admin_headers)
             return res
         except Exception as e:
@@ -71,8 +70,7 @@ class SplitPayments:
         `percent` can up to 6 decimal places
         """
         try:
-            upath = self.splitpath
-            path = self._lnbits_url + upath
+            path = self._lnbits_url + self.splitpath
 
             # check if there are other targets to avoid overwriting
             targets = await self.get_target_wallets()
@@ -104,8 +102,7 @@ class SplitPayments:
         200 OK
         """
         try:
-            upath = self.splitpath
-            path = self._lnbits_url + upath
+            path = self._lnbits_url + self.splitpath
             res = await delete_url(self._session, path=path, headers=self._admin_headers)
             # response body is null when successful.
             return res

--- a/pylnbits/split_payments.py
+++ b/pylnbits/split_payments.py
@@ -85,7 +85,8 @@ class SplitPayments:
             
             # response body is null when successful. Return the updated list
             if res is None:
-                return body
+                updatedlist = await self.get_target_wallets()
+                return {"targets" : updatedlist}
             return res
         except Exception as e:
             logger.info(e)

--- a/pylnbits/split_payments.py
+++ b/pylnbits/split_payments.py
@@ -85,6 +85,7 @@ class SplitPayments:
             if res is None:
                 updatedlist = await self.get_target_wallets()
                 return {"targets" : updatedlist}
+            
             return res
         except Exception as e:
             logger.info(e)

--- a/pylnbits/split_payments.py
+++ b/pylnbits/split_payments.py
@@ -3,7 +3,7 @@ import logging
 
 from aiohttp.client import ClientSession
 
-from pylnbits.utils import delete_url, get_url, post_url
+from pylnbits.utils import delete_url, get_url, put_url
 
 """
 Rest API methods for LNbits Split Payments Extension
@@ -51,6 +51,62 @@ class SplitPayments:
             upath = self.splitpath
             path = self._lnbits_url + upath
             res = await get_url(self._session, path=path, headers=self._admin_headers)
+            return res
+        except Exception as e:
+            logger.info(e)
+            return e
+    
+    # Add target wallet
+    async def add_target_wallet(self, wallet: str, alias: str, percent: float):
+        """
+        PUT /splitpayments/api/v1/targets
+
+        Headers
+        {"X-Api-Key": "Admin key"}
+
+        Returns null 
+        200 OK (application/json)
+        
+        `wallet` can either be a lightning address, lnurl, lnbits internal wallet id.
+        `percent` can up to 6 decimal places
+        """
+        try:
+            upath = self.splitpath
+            path = self._lnbits_url + upath
+
+            # check if there are other targets to avoid overwriting
+            targets = await self.get_target_wallets()
+            data = [{"wallet": wallet, "alias" : alias, "percent": percent}]
+            if targets is not None:
+                data = targets + data
+            body = {"targets": data}
+            j = json.dumps(body)
+            res = await put_url(self._session, path=path, headers=self._admin_headers, body=j)
+            
+            # response body is null when successful. Return the updated list
+            if res is None:
+                return body
+            return res
+        except Exception as e:
+            logger.info(e)
+            return e
+        
+    # Delete all target wallets
+    async def delete_target_wallets(self):
+        """
+        DELETE /splitpayments/api/v1/targets
+
+        Headers
+        {"X-Api-Key": "Admin key"}
+
+        Returns null 
+        200 OK
+        """
+        try:
+            upath = self.splitpath
+            path = self._lnbits_url + upath
+            res = await delete_url(self._session, path=path, headers=self._admin_headers)
+            # response body is null when successful.
             return res
         except Exception as e:
             logger.info(e)

--- a/pylnbits/split_payments.py
+++ b/pylnbits/split_payments.py
@@ -1,0 +1,57 @@
+import json
+import logging
+
+from aiohttp.client import ClientSession
+
+from pylnbits.utils import delete_url, get_url, post_url
+
+"""
+Rest API methods for LNbits Split Payments Extension
+
+GET target wallets
+PUT target wallet
+DELETE target wallets
+"""
+
+###################################
+logging.basicConfig(level=logging.INFO,
+                    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logging.getLogger("pylnbits").setLevel(level=logging.WARNING)
+logger = logging.getLogger(__name__)
+###################################
+
+class SplitPayments:
+    def __init__(self, config, session: ClientSession = None):
+        """__init__
+
+            Initializes a Split Payments extension via API
+
+        """
+        self._session = session
+        self._config = config
+        self._lnbits_url = config.lnbits_url
+        self._invoice_headers = config.invoice_headers()
+        self._admin_headers = config.admin_headers()
+        self.splitpath = "/splitpayments/api/v1/targets"
+
+    # Return list of target wallets
+    async def get_target_wallets(self):
+        """
+        GET /splitpayments/api/v1/targets
+
+        Headers
+        {"X-Api-Key": "Admin key"}
+
+        Returns an array 
+        200 OK (application/json)
+        [{'wallet': <string>, 'source': <string>, 'percent': <float>, 'alias': <string>}]
+
+        """
+        try:
+            upath = self.splitpath
+            path = self._lnbits_url + upath
+            res = await get_url(self._session, path=path, headers=self._admin_headers)
+            return res
+        except Exception as e:
+            logger.info(e)
+            return e

--- a/tests/test_splitpayments.py
+++ b/tests/test_splitpayments.py
@@ -15,9 +15,19 @@ async def main():
 
     async with ClientSession() as session:
         sp = SplitPayments(c, session)
-        # works
-        targetwallets = await sp.get_target_wallets()
-        print(f"target wallets : {targetwallets}")
+
+        # get list of target wallets
+        # targetwallets = await sp.get_target_wallets()
+        # print(f"Target wallets : {targetwallets}")
+
+        # add target wallets
+        # addwallets = await sp.add_target_wallet("me@example.com", "Me", 50)
+        # print(f"Updated list of target wallets: {addwallets}")
+
+        # delete list of target wallets
+        deletewallets = await sp.delete_target_wallets()
+        print(f"status: {deletewallets}")
+
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())

--- a/tests/test_splitpayments.py
+++ b/tests/test_splitpayments.py
@@ -17,16 +17,16 @@ async def main():
         sp = SplitPayments(c, session)
 
         # get list of target wallets
-        # targetwallets = await sp.get_target_wallets()
-        # print(f"Target wallets : {targetwallets}")
+        targetwallets = await sp.get_target_wallets()
+        print(f"Target wallets : {targetwallets}")
 
         # add target wallets
-        # addwallets = await sp.add_target_wallet("me@example.com", "Me", 50)
-        # print(f"Updated list of target wallets: {addwallets}")
+        addwallets = await sp.add_target_wallet("me@example.com", "Me", 50)
+        print(f"Updated list of target wallets: {addwallets}")
 
         # delete list of target wallets
-        deletewallets = await sp.delete_target_wallets()
-        print(f"status: {deletewallets}")
+        # deletewallets = await sp.delete_target_wallets()
+        # print(f"status: {deletewallets}")
 
 
 loop = asyncio.get_event_loop()

--- a/tests/test_splitpayments.py
+++ b/tests/test_splitpayments.py
@@ -1,0 +1,23 @@
+import asyncio
+
+from aiohttp.client import ClientSession
+
+from pylnbits.config import Config
+from pylnbits.split_payments import SplitPayments
+
+async def main():
+
+    c = Config(config_file="config.yml")
+    url = c.lnbits_url
+    print(f"url: {url}")
+    print(f"headers: {c.headers()}")
+    print(f"admin_headers: {c.admin_headers()}")
+
+    async with ClientSession() as session:
+        sp = SplitPayments(c, session)
+        # works
+        targetwallets = await sp.get_target_wallets()
+        print(f"target wallets : {targetwallets}")
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main())

--- a/tests/test_userwallet.py
+++ b/tests/test_userwallet.py
@@ -43,6 +43,20 @@ async def main():
         res = await uw.pay_invoice(True, bolt)
         print(res)
 
+        # pay lnurl
+        # This is a fictional LNURL for example purposes. Replace with your own. 
+        paylnurl = "LNURL1DP68GURN8GHJ7MRWW4EXCTNZD3SHXCTE0D3SKUM0W4KHU7DF89KHK7YM89KCMRDV0658QSTVV4RY"
+        # pay_lnurl(lnurl, amount, comment, description)
+        res = await uw.pay_lnurl(paylnurl, 10, "hello", "hello")
+        print(res)
+
+        # pay lnaddress
+        # This is a fictional lightning address for example purposes. Replace with your own. 
+        lnaddress = "wonderful@example.com"
+        # pay_lnaddress(lnurl, amount, comment, description)
+        res = await uw.pay_lnaddress(lnaddress, 10, "sunshine", "hello")
+        print(res)
+
 
 loop = asyncio.get_event_loop()
 loop.run_until_complete(main())


### PR DESCRIPTION
Added module for Split Payments extension. Module allows you to:

- Get list of target wallets
- Add target wallets
- Delete all target wallets

P.S.
Also added test examples for pay lnurl and paylnaddress in test_userwallet.py (To-do in #142)